### PR TITLE
fix reflexive object property

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -74,11 +74,17 @@
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter</artifactId>
-            <version>5.7.1</version>
+            <artifactId>junit-jupiter-params</artifactId>
+            <version>5.10.2</version>
             <scope>test</scope>
         </dependency>
-
+        <!-- https://mvnrepository.com/artifact/org.junit.jupiter/junit-jupiter-engine -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <version>5.10.2</version>
+            <scope>test</scope>
+        </dependency>
         <!-- https://mvnrepository.com/artifact/org.junit.platform/junit-platform-runner -->
         <dependency>
             <groupId>org.junit.platform</groupId>
@@ -86,7 +92,6 @@
             <version>1.7.0</version>
             <scope>test</scope>
         </dependency>
-
 
         <!-- https://mvnrepository.com/artifact/joda-time/joda-time -->
         <dependency>
@@ -156,6 +161,13 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <!-- JUnit 5 requires Surefire version 2.22.0 or higher -->
+                <version>2.22.0</version>
+            </plugin>
+
 
         </plugins>
     </build>

--- a/java/src/main/java/translation/OWLAxiomTranslator.java
+++ b/java/src/main/java/translation/OWLAxiomTranslator.java
@@ -274,12 +274,16 @@ public class OWLAxiomTranslator extends OWLTranslator implements OWLAxiomVisitor
     //ReflexiveObjectProperty
     @Override
     public ArrayList<LogicElement> visit(OWLReflexiveObjectPropertyAxiom axiom) {
+        OWLDataFactory df = OWLManager.getOWLDataFactory();
         ArrayList<LogicElement> res = new ArrayList<>();
         Variable var1 = getUniqueVariable();
         res.add(new QuantifiedFormula(
             new Quantifier(0), // universal quantifier
             new Variable[]{var1},
-            axiom.getProperty().accept(new OWLPropertyExpressionTranslator(var1, var1))));
+            new BinaryFormula(
+                df.getOWLThing().accept(new OWLClassExpressionTranslator(var1)),
+                new BinaryConnective(3), // implication
+                axiom.getProperty().accept(new OWLPropertyExpressionTranslator(var1, var1)))));
         return res;
     }
 

--- a/java/src/test/java/testAxiomTranslator/TestReflexiveObjectProperty.java
+++ b/java/src/test/java/testAxiomTranslator/TestReflexiveObjectProperty.java
@@ -4,11 +4,15 @@ import fol.LogicElement;
 import fol.QuantifiedFormula;
 import fol.Quantifier;
 import fol.Variable;
+import fol.BinaryFormula;
+import fol.BinaryConnective;
 import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.api.Test;
 import org.semanticweb.owlapi.apibinding.OWLManager;
 import org.semanticweb.owlapi.model.OWLDataFactory;
 import org.semanticweb.owlapi.model.OWLObjectPropertyExpression;
 import translation.OWLPropertyExpressionTranslator;
+import translation.OWLClassExpressionTranslator;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -29,7 +33,11 @@ public class TestReflexiveObjectProperty extends StandardAxiomTest {
                     new QuantifiedFormula(
                         new Quantifier(0),
                         new Variable[]{var0},
-                        testProperty0.accept(new OWLPropertyExpressionTranslator(var0, var0))
+                        new BinaryFormula(
+                            df.getOWLThing().accept(new OWLClassExpressionTranslator(var0)),
+                            new BinaryConnective(3),
+                            testProperty0.accept(new OWLPropertyExpressionTranslator(var0, var0))
+                        )
                     )
                 ))
             )


### PR DESCRIPTION
closes issue #16 

I tested this for the ontology 
```
Prefix: : <http://example.com/>

Ontology:

ObjectProperty: R
  Characteristics: Reflexive
```
The FOL translation of this is now satisfiable.

I also updated the unit test and the pom.xml (unit tests are now executed during `mvn install`)

Thanks to @b-gehrke for finding this issue!